### PR TITLE
Task per aggiornare l'anagrafica

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,3 +11,21 @@ EXTRA_DIST = \
 	     meteo-vm2.pc.in \
 	     test/data/source-1.lua \
 	     test/data/1.vm2
+
+simcstations-update:
+	git pull && \
+	for f in bufr.lua default.lua; \
+	    do curl http://meteozen.metarpa/simcstations/meteo-vm2/$$f > conf/$$f; \
+	done
+
+version-update:
+	grep ^AC_INIT configure.ac && \
+	echo 'nuova versione?' && \
+	read versione && \
+	vim configure.ac fedora/SPECS/meteo-vm2.spec && \
+	echo 'procedo col commit (Ctrl-D per fermare)?' && \
+	read procedo && \
+	git commit -a -m v$${versione} && \
+	git tag v$${versione}-1 && \
+	git push && \
+	git push --tags

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,16 +16,18 @@ simcstations-update:
 	git pull && \
 	for f in bufr.lua default.lua; \
 	    do curl http://meteozen.metarpa/simcstations/meteo-vm2/$$f > conf/$$f; \
-	done
-
-version-update:
+	done && \
+	echo "### AGGIORNAMENTI ###" && \
+	git diff && \
+	read -p "Creo un nuovo pacchetto? (Ctrl-D per fermare) " procedo && \
+	echo "### VERSIONE ATTUALE ###" && \
 	grep ^AC_INIT configure.ac && \
-	echo 'nuova versione?' && \
-	read versione && \
+	read -p "Nuova versione? (Ctrl-D per fermare) " nuova_versione && \
 	vim configure.ac fedora/SPECS/meteo-vm2.spec && \
-	echo 'procedo col commit (Ctrl-D per fermare)?' && \
-	read procedo && \
-	git commit -a -m v$${versione} && \
-	git tag v$${versione}-1 && \
+	echo "### AGGIORNAMENTI ###" && \
+	git diff && \
+	read -p "Procedo col commit? (Ctrl-D per fermare) " procedo && \
+	git commit -a -m "v$${nuova_versione}" && \
+	git tag "v$${nuova_versione}-1" && \
 	git push && \
 	git push --tags

--- a/conf/bufr.lua
+++ b/conf/bufr.lua
@@ -3950,7 +3950,6 @@ return {
         [53062]={ident=nil,lon=1400230,lat=4593950,rep='fidusl',B01019='ZADLOG',B07030='7160',B07031='7160',},
         [53063]={ident=nil,lon=1402850,lat=4622210,rep='fidusl',B01019='ZGORNJA SORICA',B07030='8460',B07031='8460',},
         [53064]={ident=nil,lon=1155204,lat=4463157,rep='profe',B01019='Minerbio',B07030='60',B07031='60',},
-        [53065]={ident=nil,lon=1129002,lat=4448883,rep='simnbo',B01019='Casalecchio Canonica Valle',B07030='540',B07031='540',},
         [70000]={ident=nil,lon=1175545,lat=4421978,rep='agrmet',B01019='Brisighella',B07030='1850',B07031='1850',},
     },
     variables={

--- a/conf/default.lua
+++ b/conf/default.lua
@@ -3950,7 +3950,6 @@ return {
         [53062]={ident=nil,lon=1400230,lat=4593950,rep='fidusl',},
         [53063]={ident=nil,lon=1402850,lat=4622210,rep='fidusl',},
         [53064]={ident=nil,lon=1155204,lat=4463157,rep='profe',},
-        [53065]={ident=nil,lon=1129002,lat=4448883,rep='simnbo',},
         [70000]={ident=nil,lon=1175545,lat=4421978,rep='agrmet',},
     },
     variables={

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([meteo-vm2], [1.0.18], [edigiacomo@arpae.it])
+AC_INIT([meteo-vm2], [1.0.19], [edigiacomo@arpae.it])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/fedora/SPECS/meteo-vm2.spec
+++ b/fedora/SPECS/meteo-vm2.spec
@@ -90,6 +90,9 @@ Collection of utilities for VM2 files
 /sbin/ldconfig
 
 %changelog
+* Tue Jun 5 2020 Marcello Nuccio <mnuccio@arpae.it> - 1.0.19-1
+- Rimossa Stazione Casalecchio Canonica valle duplicata
+
 * Tue Jun 4 2020 Marcello Nuccio <mnuccio@arpae.it> - 1.0.18-1
 - Stazione idrometro Casalecchio Canonica valle
 


### PR DESCRIPTION
I passaggi per aggiornare l'anagrafica sono molti. Sono documentati su
https://simc.arpae.it/simwiki/RegoleAnagraficaMeteozen, ma è facile
perdere un passaggio.

Allora ho provato a fare un minimo di automazione creando due task nel
Makefile:

- simcstations-update scarica la nuova anagrafica da meteozen

- version-update da un aiuto per creare il nuovo pacchetto

Il task version-update è piuttosto grezzo e può essere ulteriormente
automatizzato incrementando automaticamente la versione ed aggiungendo
un'entry nel changelog. Ma per il momento è già un grosso aiuto.